### PR TITLE
Debugging selection code, selecting ocean, units

### DIFF
--- a/StratWeb/js/engine-gameinteract.js
+++ b/StratWeb/js/engine-gameinteract.js
@@ -25,7 +25,7 @@ export function toggleSelect(point){ //temporary, select toggling, for testing o
 	let lastUnitSelected = false; // Reset the flag
 	let nextIndex = 0;
 	if (touch.selected === 1) {
-		if (DEBUG) console.log("Something's selected. Find out what!");
+		if (DEBUG) console.log("A troop's selected. Find out which!");
 		// Find the index of the currently selected unit
 		nextIndex = nearbyUnits.findIndex(u => u.id === touch.which) + 1;
 		if (DEBUG) console.log("Current: "+touch.which+" | Next: "+nextIndex+" | Nearby: "+nearbyUnits.length);
@@ -46,10 +46,11 @@ export function toggleSelect(point){ //temporary, select toggling, for testing o
 			if (territory) {
 				if (DEBUG) console.log("Selected territory:", territory.id);
 				pickLand(territory.id); // Select the clicked territory
-			} else {
-				if (DEBUG) console.log("Clicked on ocean or non-selectable area, all lands deselected");
-				unpickAllLands(); // Deselect all lands
 			}
+		}else{
+			if (DEBUG) console.log("Clicked on ocean or non-selectable area, all lands deselected");
+			unpickAllUnits(); // Deselect all troops
+			unpickAllLands(); // Deselect all lands
 		}
 		return;
 	}

--- a/StratWeb/js/input-handler.js
+++ b/StratWeb/js/input-handler.js
@@ -1,7 +1,7 @@
 import { DEBUG } from './index.js';
 import { touch,units } from './engine-gamestate.js';
 import { translateView, doCanvasResize } from "./engine-renderer.js";
-import { toggleSelect,buildUnit } from "./engine-game.js";
+import { toggleSelect,buildUnit } from "./engine-gameinteract.js";
 
 export const buttonMove = document.getElementById("move");
 export const buttonBuild = document.getElementById("build");
@@ -51,12 +51,15 @@ function doModeSelect(){
 		touch.mode=1;
 	}
 	let point = {x:0,y:0};
-	toggleSelect(point);
 }
 function doModeMove(){
 	if(DEBUG) console.log("[Move Mode selected]");
 	if(units.length===0){
 		if(DEBUG) console.log("No units to move! Canceling...");
+		return;
+	}
+	if(touch.selected !== 1){
+		if(DEBUG) console.log("Unit not selected! Canceling...");
 		return;
 	}
 	buttonBuild.value="Build";


### PR DESCRIPTION
Code required for ensuring Move can be selected only for units, not territories, for selecting units on the ocean, and for deselecting units and land when the ocean is clicked.